### PR TITLE
Temporary fix for a parsing error of star names

### DIFF
--- a/static/js/data/string.js
+++ b/static/js/data/string.js
@@ -1,3 +1,3 @@
 function stripString(str) {
-    return str.substring(1, str.length - 1);
+    return str['key'].substring(1, str['key'].length - 1);
 }


### PR DESCRIPTION
At some point with Stellaris updates, the parsing of save games into JSON causes star names to be stored as key-value pairs with 'key' as the key, which causes the map parsing of the JSON to error as the KV object doesn't have "substring" as a function. This is a temporary workaround that appears to get the map working again with v3.4.5

Probably breaks a lot of compatibility and also doesn't address the root cause which should likely be in whatever the sav-to-JSON parser is.